### PR TITLE
Improve syntax highlighting by removing dependency on c-mode

### DIFF
--- a/hack-mode.el
+++ b/hack-mode.el
@@ -28,11 +28,6 @@
 
 ;;; Code:
 (require 'hack-xhp-indent)
-(require 'font-lock)
-(require 'cc-mode)
-(require 'cc-langs)
-(eval-when-compile
-  (require 'regexp-opt))
 
 (defgroup hack nil
   "Major mode `hack-mode' for editing Hack code."
@@ -43,589 +38,240 @@
   "The command to run to communicate with hh_server."
   :group 'hack-mode)
 
-(eval-and-compile
-  (c-add-language 'hack-mode 'c-mode))
+(defcustom hack-indent-offset 2
+  "Indentation amount (in spaces) for Hack code."
+  :group 'hack-mode)
 
-(c-lang-defconst c-recognize-post-brace-list-type-p hack t)
-(c-lang-defconst c-recognize-colon-labels hack t)
-(c-lang-defconst c-recognize-knr-p hack t)
-(c-lang-defconst qc-recognize-typeless-decls hack t)
-(c-lang-defconst c-recognize-<>-arglists hack t)
-
-(c-lang-defconst c-<>-notable-chars-re hack "[<*[];{},|&>)]")
-
-;; preprocessor stuff from c++ we turn off
-(c-lang-defconst c-opt-cpp-symbol hack nil)
-(c-lang-defconst c-opt-cpp-prefix hack nil)
-(c-lang-defconst c-anchored-cpp-prefix hack nil)
-(c-lang-defconst c-cpp-message-directives hack nil)
-(c-lang-defconst c-cpp-include-directives hack nil)
-(c-lang-defconst c-cpp-expr-directives hack nil)
-(c-lang-defconst c-cpp-expr-functions hack nil)
-
-;; Don't look for preprocessor fontification, like C does
-(c-lang-defconst c-before-font-lock-functions
-  hack 'c-change-expand-fl-region)
-
-;; I think...
-;; (c-lang-defconst c-string-escaped-newlines hack t)
-;; (c-lang-defconst comment-end-can-be-escaped hack t)
-(c-lang-defconst c-multiline-string-start-char hack t)
-
-(c-lang-defconst c-type-prefix-kwds
-  hack '("instanceof"))
-
-(c-lang-defconst c-decl-hangon-kwds hack nil)
-
-(c-lang-defconst c-opt-cpp-prefix
-  hack "<\\?\\(?:php\\|hh\\)\\s-*?")
-(c-lang-defconst c-opt-cpp-start
-  hack "<\\?\\(?:php\\|hh\\)\\s-*?")
-
-;; TODO, special fontification
-;; Hack treats comments of the forms // strict and // FALLTHROUGH in a special way.
-
-(c-lang-defconst c-basic-matchers-before
-  hack
-  `(;; Fontify keyword constants.
-    ,@(when (c-lang-const c-constant-kwds)
-        (let ((re (c-make-keywords-re nil (c-lang-const c-constant-kwds))))
-          `((eval . (list ,(concat "\\<\\(" re "\\)\\>")
-                          1 c-constant-face-name)))))
-
-    ;; Fontify leading identifiers in fully qualified names like
-    ;; "foo::bar" in languages that supports such things.
-    ,@(when (c-lang-const c-opt-identifier-concat-key)
-        `((,(byte-compile
-             ;; Must use a function here since we match longer than
-             ;; we want to move before doing a new search.  This is
-             ;; not necessary for XEmacs since it restarts the
-             ;; search from the end of the first highlighted
-             ;; submatch (something that causes problems in other
-             ;; places).
-             `(lambda (limit)
-                (while (re-search-forward
-                        ,(concat "\\(\\<" ; 1
-                                 "\\(" (c-lang-const c-symbol-key) "\\)" ; 2
-                                 (c-lang-const c-simple-ws) "*"
-                                 (c-lang-const c-opt-identifier-concat-key)
-                                 (c-lang-const c-simple-ws) "*"
-                                 "\\)"
-                                 "\\("
-                                 (c-lang-const c-opt-after-id-concat-key)
-                                 "\\)")
-                        limit t)
-                  (unless (progn
-                            (goto-char (match-beginning 0))
-                            (c-skip-comments-and-strings limit))
-                    (or (get-text-property (match-beginning 2) 'face)
-                        (c-put-font-lock-face (match-beginning 2)
-                                              (match-end 2)
-                                              c-reference-face-name))
-                    (goto-char (match-end 1)))))))))
-
-    ;; Fontify all keywords except the primitive types.
-    (,(concat "\\<" (c-lang-const c-regular-keywords-regexp))
-     1 font-lock-keyword-face)
-
-    ;; TODO, fontify ~ or other things
-    ;; fontify bangs!
-    (eval . (list "\\(!\\)[^=]" 1 c-negation-char-face-name))
-    ))
-
-(c-lang-defconst c-simple-decl-matchers
-  "Simple font lock matchers for types and declarations.  These are used
-on level 2 only and so aren't combined with `c-complex-decl-matchers'."
-
-  hack `(
-      ;; Fontify all type names and the identifiers in the
-      ;; declarations they might start.  Use eval here since
-      ;; `c-known-type-key' gets its value from
-      ;; `*-font-lock-extra-types' on mode init.
-      (eval . (list ,(c-make-font-lock-search-function
-                      'c-known-type-key
-                      '(1 'font-lock-type-face t)
-                      '((c-font-lock-declarators limit t nil)
-                        (save-match-data
-                          (goto-char (match-end 1))
-                          (c-forward-syntactic-ws))
-                        (goto-char (match-end 1))))))
-
-      ;; Fontify types preceded by `c-type-prefix-kwds' and the
-      ;; identifiers in the declarations they might start.
-      ,@(when (c-lang-const c-type-prefix-kwds)
-          (let* ((prefix-re (c-make-keywords-re nil
-                              (c-lang-const c-type-prefix-kwds)))
-                 (type-match (+ 2
-                                (regexp-opt-depth prefix-re)
-                                (c-lang-const c-simple-ws-depth))))
-            `((,(c-make-font-lock-search-function
-                 (concat "\\<\\(" prefix-re "\\)" ; 1
-                         (c-lang-const c-simple-ws) "+"
-                         (concat "\\("	; 2 + prefix-re + c-simple-ws
-                                 (c-lang-const c-symbol-key)
-                                 "\\)"))
-                 `(,type-match
-                   'font-lock-type-face t)
-                 `((c-font-lock-declarators limit t nil)
-                   (save-match-data
-                     (goto-char (match-end ,type-match))
-                     (c-forward-syntactic-ws))
-                   (goto-char (match-end ,type-match))))))))
-
-      ;; Fontify special declarations that lacks a type.
-      ,@(when (c-lang-const c-typeless-decl-kwds)
-          `((,(c-make-font-lock-search-function
-               (concat "\\<\\("
-                       (regexp-opt (c-lang-const c-typeless-decl-kwds))
-                       "\\)\\>")
-               '((c-font-lock-declarators limit t nil)
-                 (save-match-data
-                   (goto-char (match-end 1))
-                   (c-forward-syntactic-ws))
-                 (goto-char (match-end 1)))))))
-
-      ;; Fontify generic colon labels in languages that support them.
-      ,@(when (c-lang-const c-recognize-colon-labels)
-          `(c-font-lock-labels))))
-
-(c-lang-defconst c-basic-matchers-after
-
-  hack `(
-         ;; Really super simple variable highlighting
-         ("\\$\\(this\\)" 1 c-reference-face-name)
-         (eval . (list ,(concat "\\$\\(" (c-lang-const c-symbol-key) "\\)") 1 font-lock-variable-name-face))
-
-         ;; hack enums are separated by ; not by ,
-         ;; this seems be be the problem as we are relying on
-         ;; (c-font-lock-declarators limit t nil)
-
-         ;; ,@(when (c-lang-const c-brace-id-list-kwds)
-         ;;     ;; Fontify the remaining identifiers inside an enum list when we start
-         ;;     ;; inside it.
-         ;;     `(hack-font-lock-enum-tail
-         ;;       ;; Fontify the identifiers inside enum lists.  (The enum type
-         ;;       ;; name is handled by `c-simple-decl-matchers' or
-         ;;       ;; `c-complex-decl-matchers' below.
-         ;;       (,(c-make-font-lock-search-function
-         ;;          (concat
-         ;;           "\\<\\("
-         ;;           (c-make-keywords-re nil (c-lang-const c-brace-id-list-kwds))
-         ;;           "\\)\\>"
-         ;;           ;; Disallow various common punctuation chars that can't come
-         ;;           ;; before the '{' of the enum list, to avoid searching too far.
-         ;;           "[^][{}();/#=]*"
-         ;;           "{")
-         ;;          '((c-font-lock-declarators limit t nil)
-         ;;            (save-match-data
-         ;;              (goto-char (match-end 0))
-         ;;              (c-put-char-property (1- (point)) 'c-type
-         ;;                                   'c-decl-id-start)
-         ;;              (c-forward-syntactic-ws))
-         ;;            (goto-char (match-end 0)))))))
-
-         ;; Fontify the clauses after various keywords.
-         ,@(when (or (c-lang-const c-type-list-kwds)
-                     (c-lang-const c-ref-list-kwds)
-                     (c-lang-const c-colon-type-list-kwds))
-             `((,(c-make-font-lock-BO-decl-search-function
-                  (concat "\\<\\("
-                          (c-make-keywords-re nil
-                            (append (c-lang-const c-type-list-kwds)
-                                    (c-lang-const c-ref-list-kwds)
-                                    (c-lang-const c-colon-type-list-kwds)))
-                          "\\)\\>")
-                  '((c-fontify-types-and-refs ((c-promote-possible-types t))
-                      (c-forward-keyword-clause 1)
-                      (if (> (point) limit) (goto-char limit))))))))
-
-         ))
-
-(defun hack-font-lock-enum-tail (limit)
-  "Fontify an enum's identifiers when POINT is within the enum's brace block.
-
-  This function will be called from font-lock for a region bounded by POINT
-  and LIMIT, as though it were to identify a keyword for
-  ‘font-lock-keyword-face’.  It always returns NIL to inhibit this and
-  prevent a repeat invocation.  See elisp/lispref page 'Search-based
-  Fontification'.
-
-  NOTE: this is modified from cc-fonts to support that entries in
-  Hack enums are separated by ; rather than ,"
-  (let* ((paren-state (c-parse-state))
-         (encl-pos (c-most-enclosing-brace paren-state)))
-    (when (and
-           encl-pos
-           (eq (char-after encl-pos) ?\{)
-           (save-excursion
-             (goto-char encl-pos)
-             (c-backward-over-enum-header)))
-      (c-syntactic-skip-backward "^{;" nil t)
-      (c-put-char-property (1- (point)) 'c-type 'c-decl-id-start)
-
-      (c-forward-syntactic-ws)
-
-      (c-font-lock-declarators limit t nil)))
-  nil)
-
-(c-lang-defconst c-operators
-  hack '(
-         (prefix "~")
-         (prefix "...")
-         (right-assoc "::")
-
-         ;; (right-assoc "=>")
-
-         (postfix-if-paren "<" ">")
-         (left-assoc "->" "?->" "->:" "|>" "==>")
-         (postfix "++" "--" "[" "]" "(" ")")
-
-         (prefix "++" "--" "+" "-" "!" "~" "?"
-                 "new" "clone"
-                 "(" ")" ;; Cast
-                 )
-
-         (left-assoc "*" "/" "%")
-         (left-assoc "+" "-" ".")
-
-         (left-assoc "<<" ">>")
-
-         (left-assoc "<" "<=" ">" ">=" "instanceof" "as")
-         (left-assoc "==" "!=" "|===" "!==")
-
-         (left-assoc "&")
-         (left-assoc "^")
-         (left-assoc "|")
-
-         (left-assoc "&&")
-         (left-assoc "||")
-
-         (right-assoc "$$") ;; putting this in here, but not sure about it
-
-         (right-assoc "??")
-         (left-assoc "?:")
-
-         (right-assoc "=" "+=" "-=" "*=" "**=" "/=" ".=" "%=" "&=" "|=" "^=" "<<=" ">>=")
-
-         (left-assoc "and")
-         (left-assoc "xor")
-         (left-assoc "or")
-
-         (prefix "throw")
-         (left-assoc ","))
-  )
-
-(c-lang-defconst c-identifier-ops
-  hack '((prefix "$") ;; the all-mighty dollar
-         (prefix "?") ;; nullable
-         (prefix "+") ;; in class decl <>
-         (left-assoc "::") ;; classname joiner
-         (left-assoc "\\") ;; namespace joiner
-         )
-  )
-
-(c-lang-defconst c-type-modifier-kwds hack nil)
-(c-lang-defconst c-primitive-type-kwds
-  ;; https://docs.hhvm.com/hack/types/type-system
-  ;; https://github.com/jra3/hack-langspec/blob/master/spec/05-types.md
-  hack '("arraykey" "bool" "float" "int" "num" "resource"
-         "string" "this" "void"
-
-         "mixed"
-
-         ;; not primitive, but pretty close ;)
-         "array" "vec" "dict" "keyset"
-         )
-  )
-
-(c-lang-defconst c-primitive-type-prefix-kwds hack nil)
-
-(c-lang-defconst c-brace-list-decl-kwds
-  hack '("enum"
-
-         ;; Weird syntax on these
-         "Vector" "ImmVector"
-         "Map" "ImmMap"
-         "Set" "ImmSet"
-         ))
-
-(c-lang-defconst c-typedef-kwds
-  ;; https://github.com/jra3/hack-langspec/blob/master/spec/05-type.md
-  hack '("type" "newtype"))
-
-(c-lang-defconst c-class-decl-kwds
-  hack '("class" "interface" "trait"))
-
-(c-lang-defconst c-other-block-decl-kwds
-  hack '(;; "function"
-         "namespace"))
-
-(c-lang-defconst c-modifier-kwds
-  hack '("abstract" "static" "const" "global" "final" "async"
-         ;; XHP stuff... not sure if there is a better option
-         "attribute" "children"))
-
-(c-lang-defconst c-protection-kwds
-  hack '("public" "private" "protected"))
-
-(c-lang-defconst c-postfix-decl-spec-kwds
-  hack '("extends" "implements"))
-
-(c-lang-defconst c-type-list-kwds
-  hack '("implements" "use" "require" "instanceof"))
-
-(c-lang-defconst c-ref-list-kwds
-  hack '("namespace"))  ;; may be unecessary
-
-(c-lang-defconst c-colon-type-list-re hack "[^][{};,/#=:]*:")
-(c-lang-defconst c-colon-type-list-kwds
-  hack '("enum" "function"))
-
-(c-lang-defconst c-paren-nontype-kwds
-  hack '("exit" "die" "self"))
-
-(c-lang-defconst c-block-stmt-1-kwds
-  ;; Statement keywords followed directly by a substatement.
-  hack '("do" "else" "finally" "try"))
-
-(c-lang-defconst c-block-stmt-2-kwds
-  ;; Statement keywords followed by a paren sexp and then by a substatement.
-  hack '("for" "if" "elseif" "while" "switch" "foreach" "catch"))
-
-(c-lang-defconst c-simple-stmt-kwds
-  hack '("break" "continue" "return" "yield" "namespace" "echo"
-         "include" "include_once"
-         "require" "require_once"
+(defvar hack-font-lock-keywords
+  `(
+    ;; <?hh must be on the first line. The only thing it may be preceded
+    ;; by is a shebang. See hphp.ll.
+    ;; TODO: handle //strict, //decl.
+    (,(rx
+       buffer-start
+       "<?hh")
+     . font-lock-keyword-face)
+    ;; Keywords, based on hphp.ll.
+    ;; TODO: what about ... and ?? tokens?
+    (,(regexp-opt
+       '("exit"
+         "die"
+         "const"
+         "return"
+         "yield"
+         "from"
+         "try"
+         "catch"
+         "finally"
+         "throw"
+         "using"
+         "if"
+         "else"
+         "endif"
+         "while"
+         "endwhile"
+         "do"
+         "for"
+         "endfor"
+         "foreach"
+         "endforeach"
+         "declare"
+         "enddeclare"
+         "instanceof"
+         "as"
+         "super"
+         "switch"
+         "endswitch"
+         "case"
+         "default"
+         "break"
+         "continue"
+         "goto"
+         "echo"
+         "print"
+         "class"
+         "interface"
+         "trait"
+         "insteadof"
+         "extends"
+         "implements"
+         "enum"
+         "attribute"
+         "category"
+         "children"
+         "required"
+         "function"
+         "new"
+         "clone"
+         "var"
+         "callable"
+         "eval"
+         "include"
+         "include_once"
+         "require"
+         "require_once"
+         "namespace"
+         "use"
+         "global"
+         "isset"
+         "empty"
+         "__halt_compiler"
+         "__compiler_halt_offset__"
+         "static"
+         "abstract"
+         "final"
+         "private"
+         "protected"
+         "public"
+         "unset"
+         "==>"
+         "list"
+         "array"
+         "OR"
+         "AND"
+         "XOR"
+         "dict"
+         "keyset"
+         "shape"
+         "type"
+         "newtype"
+         "where"
          "await"
-         ))
+         "vec"
+         "varray"
+         "darray"
+         "inout"
+         "async"
+         "tuple"
+         "__CLASS__"
+         "__TRAIT__"
+         "__FUNCTION__"
+         "__METHOD__"
+         "__LINE__"
+         "__FILE__"
+         "__DIR__"
+         "__NAMESPACE__"
+         "__COMPILER_FRONTEND__")
+       'symbols)
+     . font-lock-keyword-face)
+    ;; Type definitions.
+    (,(rx
+       (? "?")
+       symbol-start
+       (or
+        ;; Built-in types, based on naming_special_names.ml.
+        "void"
+        "resource"
+        "num"
+        "arraykey"
+        "noreturn"
+        "mixed"
+        "nonnull"
+        "this"
+        "dynamic"
+        "int"
+        "bool"
+        "float"
+        "string"
+        "array"
+        "darray"
+        "varray"
+        "varray_or_darray"
+        "integer"
+        "boolean"
+        "double"
+        "real"
+        "callable"
+        "object"
+        "unset"
+        ;; User-defined type.
+        (seq
+         (any upper)
+         (* (or (syntax word) (syntax symbol)))))
+       symbol-end)
+     . font-lock-type-face)
+    ;; We also highlight _ as a type, but don't highlight ?_.
+    (,(regexp-opt '("_") 'symbols)
+     . font-lock-type_face)
+    (,(regexp-opt
+       '("null"
+         "true"
+         "false")
+       'symbols)
+     . font-lock-constant-face)
 
-(c-lang-defconst c-<>-type-kwds
-  hack '( ;; new hotness
-         "vec" "keyset" "dict"
+    ;; $$ is a special variable used with the pipe operator
+    ;; |>. Highlight the entire string, to avoid confusion with $s.
+    (,(rx symbol-start "$$")
+     . font-lock-variable-name-face)
+    ;; Highlight variables that start with $, e.g. $foo. Don't
+    ;; highlight the $, to make the name easier to read (consistent with php-mode).
+    (,(rx symbol-start "$" (group (+ (or (syntax word) (syntax symbol)))) symbol-end)
+     1 font-lock-variable-name-face)
 
-         ;; old school
-         "Vector" "ImmVector"
-         "Map" "ImmMap"
-         "Set" "ImmSet"
+    ;; Constants are all in upper case, and cannot start with a
+    ;; digit. We use font-lock-variable-name-face for consistency with
+    ;; c-mode.
+    (,(rx symbol-start
+          (any upper "_")
+          (+ (any upper "_" digit))
+          symbol-end)
+     . font-lock-variable-name-face)
 
-         ;; dead school
-         "array"))
+    ;; Highlight function names.
+    (,(rx symbol-start
+          "function"
+          symbol-end
+          (+ space)
+          (group
+           symbol-start
+           (+ (or (syntax word) (syntax symbol)))
+           symbol-end))
+     1 font-lock-function-name-face)
+    ;; FALLTHROUGH and UNSAFE comments, based on full_fidelity_lexer.ml.
+    ;; TODO: UNSAFE_EXPR according to https://docs.hhvm.com/hack/typechecker/special
+    (,(rx "//"
+          (+ space)
+          (or "FALLTHROUGH" "UNSAFE"))
+     . font-lock-function-name-face)))
 
-(c-lang-defconst c-label-kwds
-  ;; Keywords introducing colon terminated labels in blocks.
-  hack '("case" "default"))
+(defvar hack-mode-syntax-table
+  (let ((table (make-syntax-table)))
+    ;; - and < are not symbol constituents.
+    (modify-syntax-entry ?- "." table)
+    (modify-syntax-entry ?< "." table)
+    (modify-syntax-entry ?> "." table)
 
+    ;; Treat + as punctuation.
+    (modify-syntax-entry ?+ "." table)
 
-;; Hack does not support goto, continue n, or break n.
-(c-lang-defconst c-before-label-kwds hack '())
+    ;; Treat \ as punctuation, so we can navigate between different
+    ;; parts of a namespace reference.
+    (modify-syntax-entry ?\\ "." table)
 
-(c-lang-defconst c-constant-kwds
-  ;; Keywords for constants.
-  hack '("null" "true" "false"
-         "STDIN" "STDOUT" "STDERR"
+    ;; Strings
+    (modify-syntax-entry ?\" "\"" table)
+    (modify-syntax-entry ?\\ "\\" table)
+    (modify-syntax-entry ?' "\"" table)
+    ;; Comments
+    (modify-syntax-entry ?/ ". 124b" table)
+    (modify-syntax-entry ?* ". 23" table)
+    (modify-syntax-entry ?\n "> b" table)
+    (modify-syntax-entry ?\^m "> b" table)
 
-         ;; https://github.com/jra3/hack-langspec/blob/master/spec/06-constants.md#context-dependent-constants
-         "__CLASS__" "__DIR__" "__FILE__" "__FUNCTION__"
-         "__LINE__" "__METHOD__" "__NAMESPACE__" "__TRAIT__"
-
-         ;; https://github.com/jra3/hack-langspec/blob/master/spec/06-constants.md#core-predefined-constants
-         "E_ALL" "E_COMPILE_ERROR" "E_COMPILE_WARNING" "E_CORE_ERROR"
-         "E_CORE_WARNING" "E_DEPRECATED" "E_ERROR" "E_NOTICE" "E_PARSE"
-         "E_RECOVERABLE_ERROR" "E_STRICT" "E_USER_DEPRECATED"
-         "E_USER_ERROR" "E_USER_NOTICE" "E_USER_WARNING" "E_WARNING"
-         "E_USER_DEPRECATED" "INF" "M_E" "M_PI" "NAN" "PHP_EOL"
-         "PHP_INT_MAX" "PHP_INT_MIN" "PHP_INT_SIZE"))
-
-(c-lang-defconst c-inexpr-block-kwds
-  hack '("function" ;; Classic PHP anonymous functions
-         "async" ;; async blocks
-
-         "Vector" "ImmVector"
-         "Map" "ImmMap"
-         "Set" "ImmSet"
-         ))
-
-(c-lang-defconst c-other-keywords
-  ;; https://github.com/hhvm/hack-langspec/blob/master/spec/09-lexical-structure.md#keywords
-  hack '("await" "classname" "insteadof" "noreturn"
-         "parent" "self" "static" "shape" "using"
-         "echo" "tuple" "list" "empty" "isset" "unset"
-         "fun" "inst_meth" "inst_meth" "meth_caller"
-         ))
-
-;; Fix indentation for enums
-(c-lang-defconst c-opt-block-decls-with-vars-key hack nil)
-
-;; TODO
-;; (defvar c-promote-possible-types nil)
-
-(defcustom hack-font-lock-extra-types
-  '(
-    "__Override"
-    "__ConsistentConstruct"
-    "__Memoize"
-    "__Deprecated"
-    "__MockClass"
-    "__IsFoldable"
-    "__Native"
-    )
-  "*List of extra types (aside from the type keywords) in hack mode.
-Each list item should be a regexp matching a single identifier."
-  :group 'hack-mode
-  :type 'list
-  )
-
-(c-lang-defconst c-font-lock-extra-types
-  hack hack-font-lock-extra-types)
-
-(c-lang-defconst c-matchers-2
-  hack (append
-        (c-lang-const c-matchers-1)
-        (c-lang-const c-basic-matchers-before)
-        (c-lang-const c-simple-decl-matchers)
-        (c-lang-const c-basic-matchers-after)
-        ))
-
-(c-lang-defconst c-matchers-3
-  hack (append
-        (c-lang-const c-matchers-1)
-        (c-lang-const c-basic-matchers-before)
-        (c-lang-const c-complex-decl-matchers)
-        (c-lang-const c-basic-matchers-after)
-        ))
-
-(defconst hack-font-lock-keywords-1 (c-lang-const c-matchers-1 hack)
-  "Minimal highlighting for hack mode.")
-
-(defconst hack-font-lock-keywords-2 (c-lang-const c-matchers-2 hack)
-  "Fast normal highlighting for hack mode.")
-
-(defconst hack-font-lock-keywords-3 (c-lang-const c-matchers-2 hack)
-  "Accurate normal highlighting for hack mode.")
-
-(defvar hack-font-lock-keywords hack-font-lock-keywords-2
-  "Default expressions to highlight in hack mode.")
-
-(defvar hack-mode-syntax-table nil
-  "Syntax table used in ‘hack-mode’ buffers.")
-(or hack-mode-syntax-table
-    (setq hack-mode-syntax-table
-          (let ((table (funcall (c-lang-const c-make-mode-syntax-table hack))))
-
-            ;; '#' style comments
-            (modify-syntax-entry ?# "< b" table)
-
-            ;; '/* ... */' and '//' style comments
-            (modify-syntax-entry ?/ ". 124b" table)
-            (modify-syntax-entry ?* ". 23" table)
-
-            ;; newlines end '//' and '#' comments
-            (modify-syntax-entry ?\n "> b" table)
-
-            ;; $ and type prefixed to be treated as a 'Character quote'
-            (modify-syntax-entry ?$ "/" table)
-            ;; (modify-syntax-entry ?? "/" table)
-            ;; (modify-syntax-entry ?+ "/" table)
-
-            ;; Single quotes and backticks highlighted as strings
-            (modify-syntax-entry ?' "\"" table)
-            (modify-syntax-entry ?` "\"" table)
-
-            ;; Give underscore "word" syntax (todo, should be symbol?)
-            (modify-syntax-entry ?_ "w" table)
-
-            ;; ;; Horrible hack to keep annotations from screwing up
-            ;; ;; indentation of method decls and classes
-            ;; (modify-syntax-entry ?< "_" table)
-            ;; (modify-syntax-entry ?> "_" table)
-
-            ;; xhp symbol syntax
-            ;; (modify-syntax-entry ?- "_" table)
-            ;; (modify-syntax-entry ?: "_" table)
-
-            table)))
-
-(defvar hack-mode-abbrev-table nil
-  "Abbreviation table used in ‘hack-mode’ buffers.")
-(c-define-abbrev-table 'hack-mode-abbrev-table
-  ;; Use the abbrevs table to trigger indentation actions
-  ;; on keywords that, if they occur first on a line, might alter the
-  ;; syntactic context.
-  ;; Syntax for abbrevs is:
-  ;; ( pattern replacement command initial-count)
-  '(("else" "else" c-electric-continued-statement 0)
-    ("while" "while" c-electric-continued-statement 0)
-    ("catch" "catch" c-electric-continued-statement 0)
-    ("finally" "finally" c-electric-continued-statement 0)))
-
-(defvar hack-mode-map ()
-  "Keymap used in ‘hack-mode’ buffers.")
-(if hack-mode-map
-    nil
-  (setq hack-mode-map (c-make-inherited-keymap))
-
-  ;; Workaround to make our custom xhp indentation work with c-mode
-  (substitute-key-definition
-   'c-indent-line-or-region
-   'indent-for-tab-command
-   hack-mode-map)
-  )
-
-(defun hack-lineup-arglist-intro (langelem)
-  "Indent code at the beginning of function arglists.
-Argument LANGELEM the location of the start of the arglist"
-  (save-excursion
-    (goto-char (cdr langelem))
-    (vector (+ (current-column) c-basic-offset))))
-
-(defun hack-lineup-arglist-cont (langelem)
-  "Indent chained function calls inside of arg lists
-Argument LANGELEM the location of the start of the arglist"
-  (save-excursion
-    (back-to-indentation)  ;; first non-whitespace char
-    (let ((fn-cont (looking-at "->")))
-      (goto-char (cdr langelem))
-      (if fn-cont
-          (vector (+ (current-column) c-basic-offset))
-        (vector (current-column))))))
-
-(defun hack-lineup-arglist-close (langelem)
-  "Indent code at the close of function arglists.
-Argument LANGELEM the location of the close of the arglist"
-  (save-excursion
-    (goto-char (cdr langelem))
-    (vector (current-column))))
-
-(defconst hack-style
-  '((c-basic-offset . 2)
-    (c-offsets-alist . ((stream-op . 0) ;; << and >> are not stream ops...
-                        (access-label . 0)
-                        (arglist-intro . hack-lineup-arglist-intro)
-                        (arglist-cont . hack-lineup-arglist-cont)
-                        (arglist-close . hack-lineup-arglist-close)
-                        )))
-  "Default Hack Programming style.")
-(c-add-style "hack" hack-style)
+    table))
 
 ;; hh_server can choke if you symlink your www root
 (setq find-file-visit-truename t)
 
-;;;###autoload
-(define-derived-mode hack-mode c-mode "Hack"
-  "A major mode for Hack files\n\n\\{hack-mode-map}"
-  (c-initialize-cc-mode t)
-  (c-init-language-vars hack-mode)
-  (c-common-init 'hack-mode)
+(define-derived-mode hack-mode prog-mode "Hack"
+  "Major mode for editing Hack code.
 
-  (setq-local font-lock-maximum-decoration t)
-  (setq-local case-fold-search t)
+\\{hack-mode-map\\}"
+  (setq-local font-lock-defaults '(hack-font-lock-keywords))
   (setq-local compile-command (concat hack-client-program-name " --from emacs"))
   (setq-local indent-line-function #'hack-xhp-indent-line)
-  (c-set-style "hack")
-
-  (c-run-mode-hooks 'c-mode-common-hook 'hack-mode-hook)
-  (c-update-modeline)
-  )
+  (setq-local comment-start "// "))
 
 (provide 'hack-mode)
 ;;; hack-mode.el ends here


### PR DESCRIPTION
This changes syntax highlighting in hack-mode to be a standalone mode without using c-mode. This simplifies the logic, as we don't need to tell Emacs to ignore c-mode features that aren't applicable to hack-mode, such as the C preprocessor.

It also fixes Emacs 26 support, as some c-mode APIs have changed (e.g. c-font-lock-declarators now takes another argument) and would reliably crash when opening Hack files:

    Debugger entered--Lisp error: (wrong-type-argument stringp nil)
      search-forward-regexp(nil 138 bound)
      c-depropertize-CPP(1 138)
      #f(compiled-function (fn) #<bytecode 0x41f57035>)(c-depropertize-CPP)
      mapc(#f(compiled-function (fn) #<bytecode 0x41f57035>) (c-extend-region-for-CPP c-depropertize-CPP c-invalidate-macro-cache c-truncate-bs-cache c-parse-quotes-before-change))
      c-common-init(hack-mode)
      (let ((delay-mode-hooks t)) (c-mode) (setq major-mode 'hack-mode) (setq mode-name "Hack") (progn (if (get 'c-mode 'mode-class) (put 'hack-mode 'mode-class (get 'c-mode 'mode-class))) (if (keymap-parent hack-mode-map) nil (set-keymap-parent hack-mode-map (current-local-map))) (let ((parent (char-table-parent hack-mode-syntax-table))) (if (and parent (not (eq parent (standard-syntax-table)))) nil (set-char-table-parent hack-mode-syntax-table (syntax-table)))) (if (or (abbrev-table-get hack-mode-abbrev-table :parents) (eq hack-mode-abbrev-table local-abbrev-table)) nil (abbrev-table-put hack-mode-abbrev-table :parents (list local-abbrev-table)))) (use-local-map hack-mode-map) (set-syntax-table hack-mode-syntax-table) (setq local-abbrev-table hack-mode-abbrev-table) (c-initialize-cc-mode t) (funcall (function (lambda nil (require 'cc-langs) (let ((c-buffer-is-cc-mode 'hack-mode) (init (append (cdr c-emacs-variable-inits) (cdr c-lang-variable-inits))) current-var) (progn (make-local-variable 'comment-start) (make-local-variable 'comment-end) (make-local-variable 'comment-start-skip) (make-local-variable 'comment-end-can-be-escaped) (make-local-variable 'beginning-of-defun-function) (make-local-variable 'end-of-defun-function)) (condition-case err (let ((--dolist-tail-- init)) (while --dolist-tail-- (let ((var-init (car --dolist-tail--))) (setq current-var (car var-init)) (set (car var-init) (eval (car (cdr var-init)))) (setq --dolist-tail-- (cdr --dolist-tail--))))) (error (if current-var (message "Eval error in the `c-lang-defvar' or `c-lang-setver' for `%s' (source eval): %S" current-var err) (signal (car err) (cdr err))))))))) (c-common-init 'hack-mode) (set (make-local-variable 'font-lock-maximum-decoration) t) (set (make-local-variable 'case-fold-search) t) (set (make-local-variable 'compile-command) (concat hack-client-program-name " --from emacs")) (set (make-local-variable 'indent-line-function) (function hack-xhp-indent-line)) (c-set-style "hack") (run-mode-hooks 'c-mode-common-hook 'hack-mode-hook) (c-update-modeline))
      (progn (make-local-variable 'delay-mode-hooks) (let ((delay-mode-hooks t)) (c-mode) (setq major-mode 'hack-mode) (setq mode-name "Hack") (progn (if (get 'c-mode 'mode-class) (put 'hack-mode 'mode-class (get 'c-mode 'mode-class))) (if (keymap-parent hack-mode-map) nil (set-keymap-parent hack-mode-map (current-local-map))) (let ((parent (char-table-parent hack-mode-syntax-table))) (if (and parent (not (eq parent (standard-syntax-table)))) nil (set-char-table-parent hack-mode-syntax-table (syntax-table)))) (if (or (abbrev-table-get hack-mode-abbrev-table :parents) (eq hack-mode-abbrev-table local-abbrev-table)) nil (abbrev-table-put hack-mode-abbrev-table :parents (list local-abbrev-table)))) (use-local-map hack-mode-map) (set-syntax-table hack-mode-syntax-table) (setq local-abbrev-table hack-mode-abbrev-table) (c-initialize-cc-mode t) (funcall (function (lambda nil (require 'cc-langs) (let ((c-buffer-is-cc-mode 'hack-mode) (init (append (cdr c-emacs-variable-inits) (cdr c-lang-variable-inits))) current-var) (progn (make-local-variable 'comment-start) (make-local-variable 'comment-end) (make-local-variable 'comment-start-skip) (make-local-variable 'comment-end-can-be-escaped) (make-local-variable 'beginning-of-defun-function) (make-local-variable 'end-of-defun-function)) (condition-case err (let ((--dolist-tail-- init)) (while --dolist-tail-- (let ((var-init (car --dolist-tail--))) (setq current-var (car var-init)) (set (car var-init) (eval (car (cdr var-init)))) (setq --dolist-tail-- (cdr --dolist-tail--))))) (error (if current-var (message "Eval error in the `c-lang-defvar' or `c-lang-setver' for `%s' (source eval): %S" current-var err) (signal (car err) (cdr err))))))))) (c-common-init 'hack-mode) (set (make-local-variable 'font-lock-maximum-decoration) t) (set (make-local-variable 'case-fold-search) t) (set (make-local-variable 'compile-command) (concat hack-client-program-name " --from emacs")) (set (make-local-variable 'indent-line-function) (function hack-xhp-indent-line)) (c-set-style "hack") (run-mode-hooks 'c-mode-common-hook 'hack-mode-hook) (c-update-modeline)))
      hack-mode()
      funcall-interactively(hack-mode)
      call-interactively(hack-mode record nil)
      command-execute(hack-mode record)

Syntax highlighting is now based on the lexer used by Hack, ensuring that we have full coverage (e.g. nonnull was missing before). Variables $foo are highlighted, but the $ itself is not, to make it easy to focus on the name (the same as php-mode).

Function and method names are now also highlighted.