### PR TITLE
Treat & as punctuation

### DIFF
--- a/hack-mode.el
+++ b/hack-mode.el
@@ -245,6 +245,9 @@
     ;; Treat + as punctuation.
     (modify-syntax-entry ?+ "." table)
 
+    ;; Treat & as punctuation.
+    (modify-syntax-entry ?& "." table)
+
     ;; Treat \ as punctuation, so we can navigate between different
     ;; parts of a namespace reference.
     (modify-syntax-entry ?\\ "." table)


### PR DESCRIPTION
References are discouraged, but work in partial mode:
https://docs.hhvm.com/hack/unsupported/references

Ensure that we recognise `$foo` is the variable name in `&$foo`.